### PR TITLE
Optimize module logging

### DIFF
--- a/modules/oracle/keeper/keeper.go
+++ b/modules/oracle/keeper/keeper.go
@@ -215,8 +215,8 @@ func (k Keeper) EditFeed(ctx sdk.Context, msg *types.MsgEditFeed) error {
 	return nil
 }
 
-// HandlerResponse is responsible for processing the data returned from the servicetypes module,
-// processed by the aggregate function, and then saved
+// HandlerResponse is responsible for processing the data returned from the service module,
+// processed by the aggregation function, and then saved
 func (k Keeper) HandlerResponse(
 	ctx sdk.Context,
 	requestContextID tmbytes.HexBytes,
@@ -224,7 +224,7 @@ func (k Keeper) HandlerResponse(
 	err error,
 ) {
 	if len(responseOutput) == 0 || err != nil {
-		ctx.Logger().Error(
+		ctx.Logger().Info(
 			"Oracle feed failed",
 			"requestContextID", requestContextID.String(),
 			"err", err.Error(),

--- a/modules/random/abci.go
+++ b/modules/random/abci.go
@@ -72,5 +72,7 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
 		}
 	}
 
-	k.Logger(ctx).Info(fmt.Sprintf("%d random requests are handled", handledNormalRandReqNum))
+	if handledNormalRandReqNum > 0 {
+		k.Logger(ctx).Info(fmt.Sprintf("%d random requests are handled", handledNormalRandReqNum))
+	}
 }


### PR DESCRIPTION
1. Don't print log when no random number requests are handled in the `Random` BeginBlocker
2. Lower logging level from `Error` to `Info` when there are no responses or exists the service error in the `Oracle` response callback