### PR TITLE
refactor: adjust the length limit of classID and nftID in nft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,13 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * [\#321](https://github.com/irisnet/irismod/pull/340) The token module supports the exchange of two tokens.
 * [\#321](https://github.com/irisnet/irismod/pull/342) Refator token module .
+* [\#321](https://github.com/irisnet/irismod/pull/348) Adjust the length limit of classID and nftID in nft .
 
 ### Bug Fixes
 
 * [\#321](https://github.com/irisnet/irismod/pull/336) Fix farm genesis validate failed.
 * [\#321](https://github.com/irisnet/irismod/pull/327) Only export htlc with state=open.
+* [\#321](https://github.com/irisnet/irismod/pull/347) Fix service refund address parse error .
 
 ## [v1.7.1] - 2022-11-18
 

--- a/modules/nft/simulation/genesis.go
+++ b/modules/nft/simulation/genesis.go
@@ -11,8 +11,10 @@ import (
 )
 
 const (
-	kitties = "kitties"
-	doggos  = "doggos"
+	kitties  = "kitties"
+	doggos   = "doggos"
+	idMinLen = 3
+	idMaxLen = 101
 )
 
 // RandomizedGenState generates a random GenesisState for nft
@@ -42,7 +44,7 @@ func RandomizedGenState(simState *module.SimulationState) {
 		// 10% of accounts own an NFT
 		if simState.Rand.Intn(100) < 10 {
 			baseNFT := types.NewBaseNFT(
-				genNFTID(simState.Rand, 3, 128), // id
+				genNFTID(simState.Rand, idMinLen, idMaxLen), // id
 				simtypes.RandStringOfLength(simState.Rand, 10),
 				acc.Address,
 				simtypes.RandStringOfLength(simState.Rand, 45), // tokenURI

--- a/modules/nft/simulation/operations.go
+++ b/modules/nft/simulation/operations.go
@@ -244,7 +244,7 @@ func SimulateMsgMintNFT(k keeper.Keeper, ak types.AccountKeeper, bk types.BankKe
 		randomRecipient, _ := simtypes.RandomAcc(r, accs)
 
 		msg := types.NewMsgMintNFT(
-			genNFTID(r, 3, 128),               // nft ID
+			genNFTID(r, 3, 100),               // nft ID
 			randDenom(ctx, k, r, true, false), // denom
 			"",
 			simtypes.RandStringOfLength(r, 45), // tokenURI
@@ -491,7 +491,7 @@ func randNFT(ctx sdk.Context, k keeper.Keeper, r *rand.Rand, mintable, editable 
 }
 
 func genDenomID(r *rand.Rand) string {
-	len := simtypes.RandIntBetween(r, 3, 128)
+	len := simtypes.RandIntBetween(r, 3, 100)
 	var denomID string
 	for {
 		denomID = strings.ToLower(simtypes.RandStringOfLength(r, len))

--- a/modules/nft/simulation/operations.go
+++ b/modules/nft/simulation/operations.go
@@ -244,7 +244,7 @@ func SimulateMsgMintNFT(k keeper.Keeper, ak types.AccountKeeper, bk types.BankKe
 		randomRecipient, _ := simtypes.RandomAcc(r, accs)
 
 		msg := types.NewMsgMintNFT(
-			genNFTID(r, 3, 100),               // nft ID
+			genNFTID(r, idMinLen, idMaxLen),   // nft ID
 			randDenom(ctx, k, r, true, false), // denom
 			"",
 			simtypes.RandStringOfLength(r, 45), // tokenURI
@@ -491,7 +491,7 @@ func randNFT(ctx sdk.Context, k keeper.Keeper, r *rand.Rand, mintable, editable 
 }
 
 func genDenomID(r *rand.Rand) string {
-	len := simtypes.RandIntBetween(r, 3, 100)
+	len := simtypes.RandIntBetween(r, idMinLen, idMaxLen)
 	var denomID string
 	for {
 		denomID = strings.ToLower(simtypes.RandStringOfLength(r, len))

--- a/modules/nft/types/validation.go
+++ b/modules/nft/types/validation.go
@@ -20,9 +20,9 @@ const (
 )
 
 var (
-	// DenomID or TokenID can be 3 ~ 128 characters long and support letters, followed by either
+	// DenomID or TokenID can be 3 ~ 100 characters long and support letters, followed by either
 	// a letter, a number or a separator ('/', ':', '.', '_' or '-').
-	idString = `[a-z][a-zA-Z0-9/]{2,127}`
+	idString = `[a-z][a-zA-Z0-9/]{2,100}`
 	regexpID = regexp.MustCompile(fmt.Sprintf(`^%s$`, idString)).MatchString
 
 	keywords          = strings.Join([]string{ReservedPeg, ReservedIBC, ReservedHTLT, ReservedTIBC}, "|")

--- a/modules/nft/types/validation.go
+++ b/modules/nft/types/validation.go
@@ -20,7 +20,7 @@ const (
 )
 
 var (
-	// DenomID or TokenID can be 3 ~ 100 characters long and support letters, followed by either
+	// DenomID or TokenID can be 3 ~ 101 characters long and support letters, followed by either
 	// a letter, a number or a separator ('/', ':', '.', '_' or '-').
 	idString = `[a-z][a-zA-Z0-9/]{2,100}`
 	regexpID = regexp.MustCompile(fmt.Sprintf(`^%s$`, idString)).MatchString


### PR DESCRIPTION
Due to the inconsistency of the id length limit of the nft module in irismod and cosmos-sdk, there is a problem when querying, so it is adjusted to be consistent now